### PR TITLE
Unify crop UI into single primary panel and emphasize upload zone

### DIFF
--- a/static/css/crop.css
+++ b/static/css/crop.css
@@ -92,13 +92,12 @@ body.crop-page main {
 
 /* --- OUTER PANEL (Glass Shell) ----------------------------------------- */
 .glass-panel {
-  width: 940px;
-  display: grid;
-  grid-template-columns: 360px 1fr;
-  gap: 48px;
+  width: min(980px, 92vw);
+  display: flex;
+  flex-direction: column;
 
-  border-radius: 24px;
-  padding: 46px 54px;
+  border-radius: 28px;
+  padding: 56px 64px;
 
   background: rgba(12, 18, 22, 0.28);
   border: 1px solid rgba(0, 220, 255, 0.20);
@@ -106,23 +105,29 @@ body.crop-page main {
   -webkit-backdrop-filter: blur(18px);
 
   box-shadow:
-    0 0 26px rgba(0, 230, 255, 0.16),
-    inset 0 0 14px rgba(0, 200, 255, 0.05);
+    0 0 32px rgba(0, 230, 255, 0.22),
+    inset 0 0 18px rgba(0, 200, 255, 0.08);
 }
 
 /* --- LEFT & RIGHT MODULES ---------------------------------------------- */
 .panel {
-  background: rgba(14, 25, 32, 0.32);
-  border: 1px solid rgba(0, 200, 255, 0.12);
-
+  background: transparent;
+  border: none;
   border-radius: 20px;
-  padding: 30px 26px;
-
-  box-shadow:
-    inset 0 0 18px rgba(0, 200, 255, 0.04),
-    0 3px 14px rgba(0, 0, 0, 0.45);
+  padding: 0;
+  box-shadow: none;
 
   isolation: isolate;
+}
+
+.primary-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.settings-form {
+  margin-bottom: 18px;
 }
 
 .panel-title {
@@ -131,7 +136,7 @@ body.crop-page main {
   text-align: center;
   letter-spacing: 0.5px;
   color: #79e9ff;
-  margin-bottom: 22px;
+  margin-bottom: 18px;
 }
 
 .panel-title.small {
@@ -166,26 +171,28 @@ select:hover {
 
 /* --- UPLOAD BOX --------------------------------------------------------- */
 .upload-box {
-  margin: 10px 0 18px;
-  padding: 55px 15px;
+  margin: 14px 0 22px;
+  padding: 70px 20px;
+  min-height: 180px;
 
-  border: 2px dashed rgba(0, 220, 255, 0.40);
+  border: 2px dashed rgba(0, 240, 255, 0.65);
   border-radius: 16px;
 
   text-align: center;
-  font-size: 1.05rem;
+  font-size: 1.1rem;
   color: #dffaff;
 
-  background: rgba(10, 25, 33, 0.32);
+  background: rgba(10, 28, 38, 0.38);
   user-select: none;
   transition: 0.2s;
   cursor: pointer;
+  box-shadow: 0 0 24px rgba(0, 230, 255, 0.25);
 }
 
 .upload-box:hover {
   background: rgba(15, 40, 55, 0.40);
-  border-color: rgba(0, 255, 255, 0.70);
-  box-shadow: 0 0 20px rgba(0, 230, 255, 0.40);
+  border-color: rgba(0, 255, 255, 0.85);
+  box-shadow: 0 0 30px rgba(0, 230, 255, 0.55);
 }
 
 .upload-box input[type="file"] {
@@ -195,7 +202,7 @@ select:hover {
 .upload-box.dragover {
   background: rgba(15, 60, 80, 0.45);
   border-color: rgba(0, 255, 255, 0.85);
-  box-shadow: 0 0 22px rgba(0, 255, 255, 0.65);
+  box-shadow: 0 0 34px rgba(0, 255, 255, 0.75);
 }
 
 /* --- SLIDERS ------------------------------------------------------------ */

--- a/templates/crop.html
+++ b/templates/crop.html
@@ -12,12 +12,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
 <div class="ui-wrapper">
   <div class="glass-panel">
-
-    <!-- LEFT PANEL – SETTINGS -->
-    <div class="panel left-panel">
+    <div class="panel primary-panel">
       <h2 class="panel-title">Crop Settings</h2>
 
-      <form id="crop-form" enctype="multipart/form-data">
+      <form id="crop-form" class="settings-form" enctype="multipart/form-data">
+        <!-- Upload -->
+        <label class="label">Upload</label>
+        <div class="upload-box" id="drop-zone">
+          <label for="file-input">
+            Drop File(s) Here<br>or<br>Click to Upload
+          </label>
+        </div>
+
+        <input id="file-input" type="file" name="files" accept="image/*" multiple hidden required>
 
         <!-- Backend Preset -->
         <label class="label" for="preset">Preset</label>
@@ -38,16 +45,6 @@ document.addEventListener("DOMContentLoaded", () => {
         <select id="saved-presets">
           <option value="">Select a saved preset</option>
         </select>
-
-        <!-- Upload -->
-        <label class="label">Upload</label>
-        <div class="upload-box" id="drop-zone">
-          <label for="file-input">
-            Drop File(s) Here<br>or<br>Click to Upload
-          </label>
-        </div>
-
-        <input id="file-input" type="file" name="files" accept="image/*" multiple hidden required>
 
         <!-- Margin -->
         <label class="label" for="crop-margin">Margin</label>
@@ -94,10 +91,6 @@ document.addEventListener("DOMContentLoaded", () => {
         </div>
 
       </form>
-    </div>
-
-    <!-- RIGHT PANEL – PREVIEW + VARIANTS + PROGRESS -->
-    <div class="panel right-panel">
 
       <!-- BEFORE / AFTER -->
       <h2 class="panel-title small">Before & After</h2>
@@ -128,7 +121,6 @@ document.addEventListener("DOMContentLoaded", () => {
       <button class="download-btn" id="download-btn" disabled style="margin-top:18px;">
         Download Processed Images
       </button>
-
     </div>
 
   </div>


### PR DESCRIPTION
### Motivation
- Simplify the cropper layout by removing the left/right split and presenting controls and preview in a single focused container to reduce UI competition.
- Make the upload flow more prominent by moving the drop zone to the top of the primary container so users encounter it first.
- Reduce visual noise from multiple cards/panels so a single major panel is visually dominant on the page.

### Description
- Reworked `templates/crop.html` to replace the two-column `left-panel`/`right-panel` structure with a single `.primary-panel` and moved the upload drop zone (`#drop-zone` and `#file-input`) to the top of the form.
- Added `class="settings-form"` to the form and reorganized the markup so supporting controls sit below the upload area and preview/progress sections are stacked beneath the form.
- Updated `static/css/crop.css` to convert `.glass-panel` from a grid to a single-column layout (`display: flex; flex-direction: column;`), increased shell padding/radius, and softened nested `.panel` styles to remove competing visual cards.
- Enhanced the `.upload-box` styling (larger padding, `min-height`, stronger dashed border, brighter glow `box-shadow`, increased font size) to make the upload area visually dominant and reduced emphasis on surrounding sections.

### Testing
- Attempted to start the app with `uvicorn main:app --host 0.0.0.0 --port 8000` but the command failed because `uvicorn` was not available in the environment (command not found).
- No automated frontend or unit tests were executed for these UI-only changes in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977acb36144832f9a75420ff430a607)