### PR TITLE
Add 'Advanced Options' details wrapper for crop settings

### DIFF
--- a/static/css/crop.css
+++ b/static/css/crop.css
@@ -164,6 +164,38 @@ select:hover {
   border-color: rgba(0, 255, 255, 0.55);
 }
 
+/* --- ADVANCED OPTIONS --------------------------------------------------- */
+.advanced-options {
+  margin-top: 12px;
+  padding: 12px 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 200, 255, 0.18);
+  background: rgba(6, 16, 22, 0.35);
+}
+
+.advanced-options summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #8ddff2;
+  font-size: 0.92rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+  margin: -2px 0 14px;
+  outline: none;
+}
+
+.advanced-options summary::marker,
+.advanced-options summary::-webkit-details-marker {
+  color: rgba(0, 210, 255, 0.75);
+}
+
+.advanced-options[open] {
+  border-color: rgba(0, 210, 255, 0.35);
+  box-shadow: inset 0 0 14px rgba(0, 200, 255, 0.06);
+}
+
 /* --- UPLOAD BOX --------------------------------------------------------- */
 .upload-box {
   margin: 10px 0 18px;

--- a/templates/crop.html
+++ b/templates/crop.html
@@ -19,26 +19,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
       <form id="crop-form" enctype="multipart/form-data">
 
-        <!-- Backend Preset -->
-        <label class="label" for="preset">Preset</label>
-        <select id="preset" name="preset_label">
-          {% for item in preset_labels %}
-            <option value="{{ item.key }}">{{ item.label }}</option>
-          {% endfor %}
-        </select>
-
-        <!-- User Presets -->
-        <label class="label" for="preset-name" style="margin-top:14px;">Preset name</label>
-        <div style="display:flex; gap:10px; align-items:center;">
-          <input id="preset-name" type="text" placeholder="My custom preset" style="flex:1;">
-          <button type="button" id="save-preset-btn" class="download-btn">Save preset</button>
-        </div>
-
-        <label class="label" for="saved-presets" style="margin-top:14px;">Load preset</label>
-        <select id="saved-presets">
-          <option value="">Select a saved preset</option>
-        </select>
-
         <!-- Upload -->
         <label class="label">Upload</label>
         <div class="upload-box" id="drop-zone">
@@ -49,43 +29,67 @@ document.addEventListener("DOMContentLoaded", () => {
 
         <input id="file-input" type="file" name="files" accept="image/*" multiple hidden required>
 
-        <!-- Margin -->
-        <label class="label" for="crop-margin">Margin</label>
-        <input id="crop-margin" type="range" min="0" max="100" value="30">
+        <details class="advanced-options">
+          <summary>Advanced Options</summary>
 
-        <!-- Aspect Ratio -->
-        <label class="label" for="aspect">Aspect Ratio</label>
-        <select id="aspect" name="aspect_ratio">
-          <option value="None">None</option>
-          <option value="1:1">1×1</option>
-          <option value="4:5">4×5</option>
-          <option value="1.91:1">1.91</option>
-          <option value="9:16">9×16</option>
-          <option value="3:2">3×2</option>
-          <option value="5:4">5×4</option>
-          <option value="16:9">16×9</option>
-        </select>
+          <!-- Backend Preset -->
+          <label class="label" for="preset">Preset</label>
+          <select id="preset" name="preset_label">
+            {% for item in preset_labels %}
+              <option value="{{ item.key }}">{{ item.label }}</option>
+            {% endfor %}
+          </select>
 
-        <!-- Auto-Rotate -->
-        <div style="margin-top:14px; display:flex; align-items:center; gap:8px;">
-          <input type="checkbox" id="rotate" checked>
-          <label for="rotate" class="label" style="margin:0;">Auto-Rotate</label>
-        </div>
+          <!-- User Presets -->
+          <label class="label" for="preset-name" style="margin-top:14px;">Preset name</label>
+          <div style="display:flex; gap:10px; align-items:center;">
+            <input id="preset-name" type="text" placeholder="My custom preset" style="flex:1;">
+            <button type="button" id="save-preset-btn" class="download-btn">Save preset</button>
+          </div>
 
-        <!-- Visual Effects -->
-        <label class="label" style="margin-top:18px;" for="filter">Visual Effects</label>
-        <select id="filter" name="filter_name">
-          <option value="None">None</option>
-          <option value="Brightness">Brightness</option>
-          <option value="Contrast">Contrast</option>
-          <option value="Blur">Blur</option>
-          <option value="Edge Detection">Edge Detection</option>
-          <option value="Sepia">Sepia</option>
-        </select>
+          <label class="label" for="saved-presets" style="margin-top:14px;">Load preset</label>
+          <select id="saved-presets">
+            <option value="">Select a saved preset</option>
+          </select>
 
-        <!-- Intensity -->
-        <label class="label" style="margin-top:18px;" for="intensity">Intensity</label>
-        <input id="intensity" type="range" min="0" max="100" value="50">
+          <!-- Margin -->
+          <label class="label" for="crop-margin">Margin</label>
+          <input id="crop-margin" type="range" min="0" max="100" value="30">
+
+          <!-- Aspect Ratio -->
+          <label class="label" for="aspect">Aspect Ratio</label>
+          <select id="aspect" name="aspect_ratio">
+            <option value="None">None</option>
+            <option value="1:1">1×1</option>
+            <option value="4:5">4×5</option>
+            <option value="1.91:1">1.91</option>
+            <option value="9:16">9×16</option>
+            <option value="3:2">3×2</option>
+            <option value="5:4">5×4</option>
+            <option value="16:9">16×9</option>
+          </select>
+
+          <!-- Auto-Rotate -->
+          <div style="margin-top:14px; display:flex; align-items:center; gap:8px;">
+            <input type="checkbox" id="rotate" checked>
+            <label for="rotate" class="label" style="margin:0;">Auto-Rotate</label>
+          </div>
+
+          <!-- Visual Effects -->
+          <label class="label" style="margin-top:18px;" for="filter">Visual Effects</label>
+          <select id="filter" name="filter_name">
+            <option value="None">None</option>
+            <option value="Brightness">Brightness</option>
+            <option value="Contrast">Contrast</option>
+            <option value="Blur">Blur</option>
+            <option value="Edge Detection">Edge Detection</option>
+            <option value="Sepia">Sepia</option>
+          </select>
+
+          <!-- Intensity -->
+          <label class="label" style="margin-top:18px;" for="intensity">Intensity</label>
+          <input id="intensity" type="range" min="0" max="100" value="50">
+        </details>
 
         <!-- Buttons -->
         <div style="display:flex; gap:10px; margin-top:22px;">


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the left settings panel by collapsing less-frequently-used controls under an expandable section. 
- Keep the upload drop zone visually primary while still exposing presets, margin, aspect, rotation, effects and intensity when needed.

### Description
- Wrap the preset controls, preset save/load, margin, aspect ratio, auto-rotate, visual effects and intensity inside a `<details class="advanced-options">` element with a `<summary>` label `Advanced Options` placed below the upload drop zone in `templates/crop.html`, leaving the element closed by default. 
- Add styles in `static/css/crop.css` for `.advanced-options`, `.advanced-options summary`, marker styling, and the `[open]` state to make the panel visually secondary to the drop zone while fitting the existing UI theme. 
- Updated markup and styles across `templates/crop.html` and `static/css/crop.css` to implement the new collapsible section.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977acb47344832fb863322d7479d57d)