### PR TITLE
Consolidate crop actions into a single “Start Processing” primary button

### DIFF
--- a/static/css/crop.css
+++ b/static/css/crop.css
@@ -279,7 +279,7 @@ input[type="range"]::-webkit-slider-thumb {
 }
 
 /* --- BUTTONS ------------------------------------------------------------ */
-.download-btn {
+.primary-btn {
   width: 100%;
   padding: 14px 0;
 
@@ -297,12 +297,40 @@ input[type="range"]::-webkit-slider-thumb {
   box-shadow: 0 0 20px rgba(0, 240, 255, 0.28);
 }
 
-.download-btn:hover:not(:disabled) {
+.primary-btn:hover:not(:disabled) {
   transform: translateY(-2px);
   box-shadow: 0 0 28px rgba(0, 240, 255, 0.42);
 }
 
-.download-btn:disabled {
+.primary-btn:disabled {
   opacity: 0.55;
+  cursor: default;
+}
+
+.download-btn {
+  width: 100%;
+  padding: 12px 0;
+
+  border-radius: 14px;
+  font-size: 0.95rem;
+  font-weight: 600;
+
+  border: 1px solid rgba(0, 220, 255, 0.35);
+  cursor: pointer;
+
+  background: rgba(6, 18, 26, 0.6);
+  color: #c9f5ff;
+
+  transition: 0.15s;
+}
+
+.download-btn:hover:not(:disabled) {
+  border-color: rgba(0, 240, 255, 0.6);
+  box-shadow: 0 0 18px rgba(0, 200, 255, 0.22);
+  transform: translateY(-1px);
+}
+
+.download-btn:disabled {
+  opacity: 0.5;
   cursor: default;
 }

--- a/static/js/crop.js
+++ b/static/js/crop.js
@@ -11,8 +11,7 @@ const rotateCheckbox = document.getElementById("rotate");
 const filterSelect   = document.getElementById("filter");
 const intensityInput = document.getElementById("intensity");
 
-const previewBtn     = document.getElementById("preview-btn");
-const processBtn     = document.getElementById("process-btn");
+const startProcessingBtn = document.getElementById("start-processing-btn");
 
 const previewBox     = document.getElementById("preview-box");
 const progressFill   = document.getElementById("progress-fill");
@@ -214,75 +213,10 @@ if (dropZone && fileInput) {
 
 
 // ===============================
-// Preview Button (minor change: still sends preset key)
+// Start Processing (unchanged API contract)
 // ===============================
-if (previewBtn) {
-    previewBtn.addEventListener("click", async () => {
-        const files = fileInput.files;
-        if (!files || files.length === 0) {
-            alert("Please upload an image first.");
-            return;
-        }
-
-        hideErrorBanner();
-        setProgress(20);
-        setStatus("Generating crop variants...");
-
-        const variantsBox = document.getElementById("variants-box");
-        variantsBox.innerHTML = `<p class="placeholder">Generating previews...</p>`;
-
-        const formData = new FormData();
-        formData.append("file", files[0]);
-
-        const res = await fetch("/preview", { // <-- fixed endpoint
-            method: "POST",
-            body: formData,
-        });
-
-        const data = await res.json();
-        variantsBox.innerHTML = "";
-
-        if (!data.ok) {
-            variantsBox.innerHTML = `<p style="color:#f55;">${data.message}</p>`;
-            setProgress(0);
-            setStatus("Preview failed");
-            return;
-        }
-
-        window.selectedMethod = null;
-        setStatus("Select a crop variant");
-
-        Object.entries(data.variants).forEach(([method, url]) => {
-            const img = document.createElement("img");
-            img.src = url;
-            img.className = "preview-thumb";
-            img.dataset.method = method;
-
-            img.style.width = "160px";
-            img.style.cursor = "pointer";
-            img.style.border = "3px solid transparent";
-            img.style.borderRadius = "6px";
-
-            img.onclick = () => {
-                document.querySelectorAll(".preview-thumb")
-                    .forEach(x => x.style.borderColor = "transparent");
-                img.style.borderColor = "#4CAF50";
-                window.selectedMethod = method;
-                setStatus(`Selected: ${method}`);
-            };
-
-            variantsBox.appendChild(img);
-        });
-
-        setProgress(100);
-    });
-}
-
-// ===============================
-// Process All (unchanged API contract)
-// ===============================
-if (processBtn) {
-    processBtn.addEventListener("click", async () => {
+if (startProcessingBtn) {
+    startProcessingBtn.addEventListener("click", async () => {
         const files = fileInput.files;
         if (!files || files.length === 0) {
             alert("Please upload at least one image.");

--- a/templates/crop.html
+++ b/templates/crop.html
@@ -49,6 +49,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
         <input id="file-input" type="file" name="files" accept="image/*" multiple hidden required>
 
+        <button type="button" id="start-processing-btn" class="primary-btn" style="margin:4px 0 18px;">
+          Start Processing
+        </button>
+
         <!-- Margin -->
         <label class="label" for="crop-margin">Margin</label>
         <input id="crop-margin" type="range" min="0" max="100" value="30">
@@ -86,12 +90,6 @@ document.addEventListener("DOMContentLoaded", () => {
         <!-- Intensity -->
         <label class="label" style="margin-top:18px;" for="intensity">Intensity</label>
         <input id="intensity" type="range" min="0" max="100" value="50">
-
-        <!-- Buttons -->
-        <div style="display:flex; gap:10px; margin-top:22px;">
-          <button type="button" id="preview-btn" class="download-btn" style="flex:1;">Preview</button>
-          <button type="button" id="process-btn" class="download-btn" style="flex:1;">Process All</button>
-        </div>
 
       </form>
     </div>


### PR DESCRIPTION
### Motivation
- Simplify the crop UI by removing redundant Preview and Process All controls and exposing one clear primary action.
- Make the processing action visually prominent while de-emphasizing secondary actions to improve user focus and accessibility.
- Update client-side bindings so processing logic attaches to a single canonical control.

### Description
- Removed the `Preview` and `Process All` buttons from the crop form and added a single `Start Processing` button with `id="start-processing-btn"` in `templates/crop.html`.
- Introduced a `.primary-btn` style in `static/css/crop.css` for the new high-emphasis action and adjusted `.download-btn` to a lower-emphasis secondary style.
- Updated `static/js/crop.js` to reference `start-processing-btn` and removed the old `preview-btn`/`process-btn` bindings and preview logic, keeping the processing flow and API contract intact.
- Committed changes after applying the edits to the three modified files: `templates/crop.html`, `static/css/crop.css`, and `static/js/crop.js`.

### Testing
- Attempted to start the development server with `uvicorn main:app --host 0.0.0.0 --port 8000`, which failed with `command not found` because `uvicorn` is not installed in the environment.
- No automated unit or integration tests were run as part of this change set (no test harness was executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977acb59738832f9be80a95bcffccd7)