### PR TITLE
Reveal job status panel when processing starts and keep download disabled until complete

### DIFF
--- a/static/css/crop.css
+++ b/static/css/crop.css
@@ -138,6 +138,11 @@ body.crop-page main {
   color: #ffb88a;
 }
 
+/* --- JOB STATUS PANEL -------------------------------------------------- */
+#job-status-panel {
+  display: none;
+}
+
 /* --- FORMS / SELECTS / INPUTS ------------------------------------------ */
 .label {
   display: block;

--- a/static/js/crop.js
+++ b/static/js/crop.js
@@ -20,6 +20,7 @@ const statusText     = document.getElementById("status-text");
 const progressInfo   = document.getElementById("progress-info");
 const downloadBtn    = document.getElementById("download-btn");
 const errorBanner    = document.getElementById("error-banner");
+const jobStatusPanel = document.getElementById("job-status-panel");
 
 let lastZipUrl = null;
 
@@ -157,6 +158,12 @@ function showErrorBanner(code) {
     }
 }
 
+function showJobStatusPanel() {
+    if (jobStatusPanel) {
+        jobStatusPanel.style.display = "block";
+    }
+}
+
 function renderBeforeAfter(beforeUrl, afterUrl, errorMsg) {
     if (!previewBox) return;
 
@@ -289,6 +296,7 @@ if (processBtn) {
             return;
         }
 
+        showJobStatusPanel();
         const formData = new FormData();
         formData.append("preset_label", window.selectedMethod || presetSelect?.value || "");
         formData.append("margin",       marginInput?.value || 30);

--- a/templates/crop.html
+++ b/templates/crop.html
@@ -115,19 +115,21 @@ document.addEventListener("DOMContentLoaded", () => {
       <div id="error-banner"
            style="display:none; color:#ff7a7a; font-weight:bold; margin-top:10px;"></div>
 
-      <!-- PROGRESS -->
-      <h2 class="panel-title small" style="margin-top:30px;">Progress Status</h2>
-      <div class="progress-bar">
-        <div class="progress-fill" id="progress-fill"></div>
-      </div>
+      <section id="job-status-panel">
+        <!-- PROGRESS -->
+        <h2 class="panel-title small" style="margin-top:30px;">Progress Status</h2>
+        <div class="progress-bar">
+          <div class="progress-fill" id="progress-fill"></div>
+        </div>
 
-      <p id="status-text" class="status-text"></p>
-      <p id="progress-info" class="progress-info"></p>
+        <p id="status-text" class="status-text"></p>
+        <p id="progress-info" class="progress-info"></p>
 
-      <!-- DOWNLOAD -->
-      <button class="download-btn" id="download-btn" disabled style="margin-top:18px;">
-        Download Processed Images
-      </button>
+        <!-- DOWNLOAD -->
+        <button class="download-btn" id="download-btn" disabled style="margin-top:18px;">
+          Download Processed Images
+        </button>
+      </section>
 
     </div>
 


### PR DESCRIPTION
### Motivation
- Group the progress UI elements so they can be shown/hidden as a unit during a processing run.
- Avoid presenting an empty progress panel before the user starts processing and keep the download control disabled until results are available.

### Description
- Wrap the progress bar, status text, progress info, and download button in a container element `<section id="job-status-panel">` in `templates/crop.html`.
- Hide the panel by default via `#job-status-panel { display: none; }` added to `static/css/crop.css`.
- Add `const jobStatusPanel = document.getElementById("job-status-panel")` and a `showJobStatusPanel()` helper to `static/js/crop.js` and call `showJobStatusPanel()` when the user clicks the `Process All` button so the panel is revealed at processing start.
- Ensure the download button remains disabled until the server returns a valid `zip_url`, and continue updating `statusText` / `progressInfo` and progress fill during the existing processing flow.

### Testing
- Attempted to start the app with `python -m uvicorn main:app --host 0.0.0.0 --port 8000`, but it failed due to the `uvicorn` module not being available, so the UI was not exercised in a running server.
- No automated unit or integration tests were run against the UI changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977acb689fc832fbd74c70caa891610)